### PR TITLE
GH-1 Add templating for non-bean fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Added "enclosed_fields" variable for line-per-field capabilities to Java code templates
+
+## [0.2.0.0]
+### Added
 
 - Add ability to template insertion of setters (desprez)
 - Add ability to template insertion of field type (desprez)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The creator of the template replaces the following in the above:
 - `id`
   - An identifier and default value (unique within the template) to use if there is a resolution error
 - `template`
-  - Code to subsitute per field/getter set within the enclosing class. Users may use the values:
+  - Code to subsitute per field within the enclosing class. Users may use the values:
     - `${type}` to substitute the field type
     - `${name}` to substitute the field name
 - `separator`
@@ -35,7 +35,7 @@ The creator of the template replaces the following in the above:
   
 ## Example
 
-The following template uses the `enclosed_ields` variable:
+The following template uses the `enclosed_fields` variable:
 
 ```
 public ${enclosing_type}(${paramfields:enclosed_fields('${type} ${name}', ', ')}){

--- a/README.md
+++ b/README.md
@@ -12,7 +12,61 @@ The Template Dynamic Variables plug-in is hosted via Eclipse update site at the 
 
 # Use
 
-This plug-in added a variable to the available variables for use in Java code templates. The field `enclosed_bean_fields` may be used to subsitute code per occurance of a field with a matching-named getter within the class being edited. A matching-name getter has no parameters, and is named `get(field)`, with the field's first letter capitalized. Boolean fields also match against `is(field)`.
+This plug-in added two variables to the available variables for use in Java code templates. 
+
+## enclosed_fields
+
+The field `enclosed_fields` may be used to subsitute code per occurance of a field within the class being edited.
+
+The variable is used in the form
+
+`${id:enclosed_fields(template, separator)}`
+
+The creator of the template replaces the following in the above:
+
+- `id`
+  - An identifier and default value (unique within the template) to use if there is a resolution error
+- `template`
+  - Code to subsitute per field/getter set within the enclosing class. Users may use the values:
+    - `${type}` to substitute the field type
+    - `${name}` to substitute the field name
+- `separator`
+  - Code to place between each occurance of the template generated. Users may use the value `${newline}` to substitute a newline into the separator. If code formatting is enabled for templates, its application may override the resulting newlines
+  
+## Example
+
+The following template uses the `enclosed_ields` variable:
+
+```
+public ${enclosing_type}(${paramfields:enclosed_fields('${type} ${name}', ', ')}){
+  ${assignfields:enclosed_fields('this.${name} = ${name};', '${newline}')}
+}
+```
+
+If used within the class:
+
+```
+public class Example {
+
+  private String field;
+  
+  private boolean boolField;
+  
+}
+```
+
+The template would result in the code:
+
+```
+public Example(String field, boolean boolField){
+  this.field = field;
+  this.boolField = boolField;
+}
+```
+
+## enclosed_bean_fields
+
+The field `enclosed_bean_fields` may be used to subsitute code per occurance of a field with a matching-named getter within the class being edited. A matching-name getter has no parameters, and is named `get(field)`, with the field's first letter capitalized. Boolean fields also match against `is(field)`.
 
 The variable is used in the form
 

--- a/org.starchartlabs.eclipse.template.dynamic/META-INF/MANIFEST.MF
+++ b/org.starchartlabs.eclipse.template.dynamic/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.starchartlabs.eclipse.template.dynamic;singleton:=true
-Bundle-Version: 0.2.0.0
+Bundle-Version: 0.3.0.0
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.jface.text;bundle-version="3.5.0",

--- a/org.starchartlabs.eclipse.template.dynamic/OSGI-INF/l10n/bundle.properties
+++ b/org.starchartlabs.eclipse.template.dynamic/OSGI-INF/l10n/bundle.properties
@@ -3,3 +3,5 @@ resolver.description = Allows insertion of values per bean field. A bean field i
 resolver.name = Enclosed Bean Fields
 Bundle-Vendor = StarChart Labs
 Bundle-Name = Dynamic Java Code Template Variables
+resolver.description.0 = Allows insertion of values per field. Use ${name} for field name. ${type} for field type. Form ${id:enclosed_fields(template, separator, newline[boolean])}
+resolver.name.0 = Enclosed Fields

--- a/org.starchartlabs.eclipse.template.dynamic/build.properties
+++ b/org.starchartlabs.eclipse.template.dynamic/build.properties
@@ -3,4 +3,5 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               OSGI-INF/
+               OSGI-INF/,\
+               OSGI-INF/l10n/bundle.properties

--- a/org.starchartlabs.eclipse.template.dynamic/plugin.xml
+++ b/org.starchartlabs.eclipse.template.dynamic/plugin.xml
@@ -11,6 +11,13 @@
             name="%resolver.name"
             type="enclosed_bean_fields">
       </resolver>
+      <resolver
+            class="org.starchartlabs.eclipse.template.dynamic.resolver.EnclosedFieldsResolver"
+            contextTypeId="java"
+            description="%resolver.description.0"
+            name="%resolver.name.0"
+            type="enclosed_fields">
+      </resolver>
    </extension>
 
 </plugin>

--- a/org.starchartlabs.eclipse.template.dynamic/src/main/java/org/starchartlabs/eclipse/template/dynamic/resolver/EnclosedFieldsResolver.java
+++ b/org.starchartlabs.eclipse.template.dynamic/src/main/java/org/starchartlabs/eclipse/template/dynamic/resolver/EnclosedFieldsResolver.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Feb 8, 2019 StarChart Labs Authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ */
+package org.starchartlabs.eclipse.template.dynamic.resolver;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.internal.corext.template.java.CompilationUnitContext;
+import org.eclipse.jface.text.templates.TemplateContext;
+import org.eclipse.jface.text.templates.TemplateVariable;
+import org.eclipse.jface.text.templates.TemplateVariableResolver;
+
+/**
+ * Fields resolver which allows defining a template to fill for every Java field
+ *
+ * <p>
+ * The template variable resolved by this class is expected to be of the form:
+ *
+ * <pre>
+ * ${id:enclosed_fields(template, separator)}
+ * </pre>
+ *
+ * Where the user-provided values are:
+ * <ul>
+ * <li>id - identifier (unique within template) and default filler value in case of error</li>
+ * <li>template - Line to substitute per bean-field. May use ${type} within to substitute field type, ${name} within to
+ * substitute field name</li>
+ * <li>separator - value, if any, to place between each occurrence of the substituted template. May use ${newline} to
+ * substitute in a System.lineSeparator(). Resulting new-lines will be overridden by code formatter if it is enabled for
+ * the template</li>
+ * </ul>
+ *
+ * <p>
+ * This class is intended to be extensible
+ *
+ * <p>
+ * References:
+ * <ul>
+ * <li>org.eclipse.jface.text.templates.TemplateVariable</li>
+ * <li>org.eclipse.jdt.internal.corext.template.java.CompilationUnitContextType</li>
+ * <li>org.eclipse.jdt.internal.corext.template.java.JavaContextType</li>
+ * <li>https://stackoverflow.com/questions/350600/eclipse-custom-variable-for-java-code-templates</li>
+ * <li>https://help.eclipse.org/mars/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fapi%2Forg%2Feclipse%2Fjface%2Ftext%2Ftemplates%2FTemplateVariableResolver.html</li>
+ * <li>http://help.eclipse.org/kepler/index.jsp?topic=%2Forg.eclipse.jdt.doc.user%2Fconcepts%2Fconcept-template-variables.htm</li>
+ * </ul>
+ *
+ * @author romeara
+ * @since 0.3.0
+ */
+@SuppressWarnings("restriction")
+public class EnclosedFieldsResolver extends TemplateVariableResolver {
+
+    protected static final String TYPE_PLACEHOLDER = "\\$\\{type\\}";
+
+    protected static final String NAME_PLACEHOLDER = "\\$\\{name\\}";
+
+    protected static final String NEWLINE_PLACEHOLDER = "\\$\\{newline\\}";
+
+    @Override
+    public void resolve(TemplateVariable variable, TemplateContext context) {
+        if (context instanceof CompilationUnitContext) {
+            CompilationUnitContext jc = (CompilationUnitContext) context;
+
+            String[] bindings = resolveAll(jc, variable.getVariableType().getParams());
+
+            // Store the result, and if resolved set unambiguous to true to avoid trying to get user input
+            if (bindings != null) {
+                variable.setValues(bindings);
+                variable.setUnambiguous(true);
+                variable.setResolved(true);
+            } else {
+                super.resolve(variable, context);
+            }
+        } else {
+            super.resolve(variable, context);
+        }
+    }
+
+    /**
+     * Returns all possible bindings available in <code>context</code>, taking into account variable parameters
+     *
+     * @param context
+     *            The Java compilation unit context in which to resolve the type
+     * @param variableParameters
+     * @return an array of possible bindings of this type in <code>context</code>, null if binding was unsuccessful
+     */
+    protected String[] resolveAll(CompilationUnitContext context, List<String> variableParameters) {
+        String[] result = null;
+
+        if (variableParameters.size() == 2) {
+            String template = variableParameters.get(0);
+            String separator = variableParameters.get(1).replaceAll(NEWLINE_PLACEHOLDER, System.lineSeparator());
+
+            List<String> lines = new ArrayList<>();
+
+            for (Entry<String, String> entry : getFieldTypes(context).entrySet()) {
+                String processed = template
+                        .replaceAll(TYPE_PLACEHOLDER, entry.getValue())
+                        .replaceAll(NAME_PLACEHOLDER, entry.getKey());
+
+                lines.add(processed);
+            }
+
+            String value = lines.stream().collect(Collectors.joining(separator));
+            result = new String[] { value };
+        }
+
+        return result;
+    }
+
+    /**
+     * Extracts field type information from a compilation unit
+     *
+     * @param context
+     *            Information about the compilation unit the template is being inserted into
+     * @return A mapping of any bean fields to their Java type
+     */
+    protected Map<String, String> getFieldTypes(CompilationUnitContext context) {
+        Objects.requireNonNull(context);
+
+        Map<String, String> result = new LinkedHashMap<>();
+
+        try {
+            IType type = (IType) context.findEnclosingElement(IJavaElement.TYPE);
+
+            for (IField field : type.getFields()) {
+                result.put(field.getElementName(), Signature.getSignatureSimpleName(field.getTypeSignature()));
+            }
+        } catch (JavaModelException e) {
+            throw new RuntimeException(e);
+        }
+
+        return result;
+    }
+
+}


### PR DESCRIPTION
Add a template variable which allows substitution of a line per field in
a Java type.

This opens a variety of use cases, including constructor generation